### PR TITLE
Update license

### DIFF
--- a/src/Algebraic.cpp
+++ b/src/Algebraic.cpp
@@ -1,5 +1,7 @@
 /******************************************
-Copyright (c) 2019 Jo Devriendt - KU Leuven
+Copyright (c) 2010-2019 Jo Devriendt
+Copyright (c) 2010-2019 Bart Bogaerts
+Copyright (c) 2019-2024 Mate Soos
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/src/Algebraic.hpp
+++ b/src/Algebraic.hpp
@@ -1,5 +1,7 @@
 /******************************************
-Copyright (c) 2019 Jo Devriendt - KU Leuven
+Copyright (c) 2010-2019 Jo Devriendt
+Copyright (c) 2010-2019 Bart Bogaerts
+Copyright (c) 2019-2024 Mate Soos
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/src/Breaking.cpp
+++ b/src/Breaking.cpp
@@ -1,5 +1,7 @@
 /******************************************
-Copyright (c) 2019 Jo Devriendt - KU Leuven
+Copyright (c) 2010-2019 Jo Devriendt
+Copyright (c) 2010-2019 Bart Bogaerts
+Copyright (c) 2019-2024 Mate Soos
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/src/Breaking.hpp
+++ b/src/Breaking.hpp
@@ -1,5 +1,7 @@
 /******************************************
-Copyright (c) 2019 Jo Devriendt - KU Leuven
+Copyright (c) 2010-2019 Jo Devriendt
+Copyright (c) 2010-2019 Bart Bogaerts
+Copyright (c) 2019-2024 Mate Soos
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/src/Graph.cpp
+++ b/src/Graph.cpp
@@ -1,6 +1,7 @@
 /******************************************
-Copyright (c) 2019 Jo Devriendt - KU Leuven
-Copyright (c) 2019 Bart Bogaerts
+Copyright (c) 2010-2019 Jo Devriendt
+Copyright (c) 2010-2019 Bart Bogaerts
+Copyright (c) 2019-2024 Mate Soos
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/src/Graph.hpp
+++ b/src/Graph.hpp
@@ -1,6 +1,7 @@
 /******************************************
-Copyright (c) 2019 Jo Devriendt - KU Leuven
-Copyright (c) 2019 Bart Bogaerts
+Copyright (c) 2010-2019 Jo Devriendt
+Copyright (c) 2010-2019 Bart Bogaerts
+Copyright (c) 2019-2024 Mate Soos
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/src/Theory.cpp
+++ b/src/Theory.cpp
@@ -1,5 +1,7 @@
 /******************************************
-Copyright (c) 2019 Jo Devriendt - KU Leuven
+Copyright (c) 2010-2019 Jo Devriendt
+Copyright (c) 2010-2019 Bart Bogaerts
+Copyright (c) 2019-2024 Mate Soos
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/src/Theory.hpp
+++ b/src/Theory.hpp
@@ -1,5 +1,7 @@
 /******************************************
-Copyright (c) 2019 Jo Devriendt - KU Leuven
+Copyright (c) 2010-2019 Jo Devriendt
+Copyright (c) 2010-2019 Bart Bogaerts
+Copyright (c) 2019-2024 Mate Soos
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/src/breakid.cpp
+++ b/src/breakid.cpp
@@ -1,5 +1,7 @@
 /******************************************
-Copyright (c) 2019 Jo Devriendt - KU Leuven
+Copyright (c) 2010-2019 Jo Devriendt
+Copyright (c) 2010-2019 Bart Bogaerts
+Copyright (c) 2019-2024 Mate Soos
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/src/breakid.hpp
+++ b/src/breakid.hpp
@@ -1,5 +1,7 @@
 /******************************************
-Copyright (c) 2019 Jo Devriendt - KU Leuven
+Copyright (c) 2010-2019 Jo Devriendt
+Copyright (c) 2010-2019 Bart Bogaerts
+Copyright (c) 2019-2024 Mate Soos
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/src/config.hpp
+++ b/src/config.hpp
@@ -1,5 +1,7 @@
 /******************************************
-Copyright (c) 2019 Jo Devriendt - KU Leuven
+Copyright (c) 2010-2019 Jo Devriendt
+Copyright (c) 2010-2019 Bart Bogaerts
+Copyright (c) 2019-2024 Mate Soos
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
The reasoning is that Bart was pretty involved from the start, and that Mate made changes from a 2019 version. If we ever incorporate Bart's new changes, we can update the copyright accordingly.